### PR TITLE
Reduce integrations to local

### DIFF
--- a/.github/actions/e2e_template_test/action.yml
+++ b/.github/actions/e2e_template_test/action.yml
@@ -58,13 +58,13 @@ runs:
       if: ${{ inputs.ref-zenml != '' }}
       shell: bash
       run: |
-        pip install "zenml[dev, server, template]@git+https://github.com/zenml-io/zenml.git@${{ inputs.ref-zenml }}"
+        pip install "zenml[dev, server, templates]@git+https://github.com/zenml-io/zenml.git@${{ inputs.ref-zenml }}"
     
     - name: Install ZenML
       if: ${{ inputs.ref-zenml == '' }}
       shell: bash
       run: |
-        pip install zenml "zenml[dev, server, template]"
+        pip install "zenml[dev, server, templates]"
     
     - name: Concatenate requirements
       shell: bash

--- a/.github/actions/e2e_template_test/action.yml
+++ b/.github/actions/e2e_template_test/action.yml
@@ -83,3 +83,8 @@ runs:
         ZENML_STACK_NAME: ${{ inputs.stack-name }}
       run: |
         pytest ./local_checkout/tests
+
+    - name: Clean-up
+      shell: bash
+      run: |
+        rm -rf ./local_checkout

--- a/.github/actions/e2e_template_test/action.yml
+++ b/.github/actions/e2e_template_test/action.yml
@@ -58,19 +58,19 @@ runs:
       if: ${{ inputs.ref-zenml != '' }}
       shell: bash
       run: |
-        pip install "git+https://github.com/zenml-io/zenml.git@${{ inputs.ref-zenml }}" "zenml[server]@git+https://github.com/zenml-io/zenml.git@${{ inputs.ref-zenml }}"
+        pip install "zenml[dev, server, template]@git+https://github.com/zenml-io/zenml.git@${{ inputs.ref-zenml }}"
     
     - name: Install ZenML
       if: ${{ inputs.ref-zenml == '' }}
       shell: bash
       run: |
-        pip install zenml "zenml[server]"
+        pip install zenml "zenml[dev, server, template]"
     
     - name: Concatenate requirements
       shell: bash
       run: |
-        zenml integration export-requirements -o ./local_checkout/integration-requirements.txt sklearn mlflow s3 kubernetes kubeflow slack evidently
-        cat ./local_checkout/requirements.txt ./local_checkout/test-requirements.txt ./local_checkout/integration-requirements.txt >> ./local_checkout/all-requirements.txt
+        zenml integration export-requirements -o ./local_checkout/integration-requirements.txt sklearn mlflow s3 slack evidently
+        cat ./local_checkout/test-requirements.txt ./local_checkout/integration-requirements.txt >> ./local_checkout/all-requirements.txt
 
     - name: Install requirements
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           stack-name: ${{ matrix.stack-name }}
           python-version: ${{ matrix.python-version }}
-          ref-zenml: feature/OSS-2300-model-watch-tower-v0.1
+          ref-zenml: develop

--- a/template/Makefile
+++ b/template/Makefile
@@ -9,7 +9,7 @@ setup: remote-login
 setup:
 {%- endif %}
 	pip install -r requirements.txt
-	zenml integration install sklearn mlflow s3 kubernetes kubeflow slack evidently -y
+	zenml integration install sklearn mlflow slack evidently -y
 
 install-stack:
 	@echo "Specify stack name [$(stack_name)]: " && read input && [ -n "$$input" ] && stack_name="$$input" || stack_name="$(stack_name)" && \


### PR DESCRIPTION
In default delivery of the template reduces the number of integrations to local only. If remote ones are needed, the user needs a proper stack setup.