### PR TITLE
Fix for recent model changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
         with:
           stack-name: ${{ matrix.stack-name }}
           python-version: ${{ matrix.python-version }}
-          ref-zenml: ${{ inputs.ref-zenml || 'feature/PRD-566-dependency-cleanup' }}
+          ref-zenml: ${{ inputs.ref-zenml || 'bugfix/PRD-653-fix-models-linkage' }}
           ref-template: ${{ inputs.ref-template || github.ref }}

--- a/template/steps/promotion/{% if metric_compare_promotion %}compute_performance_metrics_on_current_data.py{% endif %}
+++ b/template/steps/promotion/{% if metric_compare_promotion %}compute_performance_metrics_on_current_data.py{% endif %}
@@ -46,7 +46,10 @@ def compute_performance_metrics_on_current_data(
     current_version = Model(name=latest_version.name, version=target_env)
 
     latest_version_number = latest_version.number
-    current_version_number = current_version.number
+    try:
+        current_version_number = current_version.number
+    except KeyError:
+        current_version_number = None
 
     if current_version_number is None:
         current_version_number = -1

--- a/template/steps/promotion/{% if metric_compare_promotion %}promote_with_metric_compare.py{% endif %}
+++ b/template/steps/promotion/{% if metric_compare_promotion %}promote_with_metric_compare.py{% endif %}
@@ -47,7 +47,10 @@ def promote_with_metric_compare(
     latest_version = get_step_context().model
     current_version = Model(name=latest_version.name, version=target_env)
 
-    current_version_number = current_version.number
+    try:
+        current_version_number = current_version.number
+    except KeyError:
+        current_version_number = None
 
     if current_version_number is None:
         logger.info("No current model version found - promoting latest")


### PR DESCRIPTION
## Describe changes
Now `Model(...).number` fails explicitly if no version can be fetched, while before it was just logging info and returning None.

## Pre-requisites
Please ensure you have done the following:
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have updated `ref-zenml` in `.github/workflows/ci.yml` accordingly (if you don't know - `main` would be a solid choice)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

